### PR TITLE
Change mouse input config to `type:pointer`

### DIFF
--- a/nwg_shell/skel/config/sway/config
+++ b/nwg_shell/skel/config/sway/config
@@ -92,7 +92,7 @@ input "type:touchpad" {
 }
 
 # disable acceleration for mice
-input "type:mouse" {
+input "type:pointer" {
 	accel_profile flat
 }
 


### PR DESCRIPTION
`type:mouse` is invalid ([reference](https://github.com/swaywm/sway/blob/master/sway/sway-input.5.scd)).