### PR TITLE
Arch-specific 'executor-updates' removed from default presets

### DIFF
--- a/nwg_shell/skel/config/nwg-panel/preset-0
+++ b/nwg_shell/skel/config/nwg-panel/preset-0
@@ -24,7 +24,6 @@
       "clock"
     ],
     "modules-right": [
-      "executor-updates",
       "tray",
       "button-help"
     ],
@@ -126,20 +125,6 @@
       "on-scroll-down": "",
       "css-name": "clock",
       "root-css-name": "root-clock"
-    },
-    "executor-updates": {
-      "script": "sway-check-updates",
-      "interval": 900,
-      "icon-size": 16,
-      "on-left-click": "foot sway-update",
-      "tooltip-text": "",
-      "on-middle-click": "",
-      "on-right-click": "",
-      "on-scroll-up": "",
-      "on-scroll-down": "",
-      "css-name": "",
-      "root-css-name": "",
-      "icon-placement": "left"
     },
     "sway-taskbar": {},
     "sway-workspaces": {},

--- a/nwg_shell/skel/config/nwg-panel/preset-1
+++ b/nwg_shell/skel/config/nwg-panel/preset-1
@@ -26,7 +26,6 @@
       "executor-cpuav",
       "executor-cpubar",
       "scratchpad",
-      "executor-updates",
       "tray",
       "button-help"
     ],
@@ -122,20 +121,6 @@
       "on-scroll-up": "",
       "on-scroll-down": "",
       "css-name": "clock"
-    },
-    "executor-updates": {
-      "script": "sway-check-updates",
-      "interval": 900,
-      "icon-size": 16,
-      "on-left-click": "foot sway-update",
-      "tooltip-text": "",
-      "on-middle-click": "",
-      "on-right-click": "",
-      "on-scroll-up": "",
-      "on-scroll-down": "",
-      "css-name": "",
-      "root-css-name": "",
-      "icon-placement": "left"
     },
     "width": "auto",
     "sway-workspaces": {

--- a/nwg_shell/skel/config/nwg-panel/preset-2
+++ b/nwg_shell/skel/config/nwg-panel/preset-2
@@ -23,7 +23,6 @@
     "modules-right": [
       "executor-cpuavg",
       "executor-cpubar",
-      "executor-updates",
       "clock",
       "tray",
       "button-help"
@@ -139,20 +138,6 @@
       "on-scroll-down": "",
       "css-name": "clock",
       "root-css-name": "root-clock"
-    },
-    "executor-updates": {
-      "script": "sway-check-updates",
-      "interval": 900,
-      "icon-size": 16,
-      "on-left-click": "foot sway-update",
-      "tooltip-text": "",
-      "on-middle-click": "",
-      "on-right-click": "",
-      "on-scroll-up": "",
-      "on-scroll-down": "",
-      "css-name": "",
-      "root-css-name": "",
-      "icon-placement": "left"
     },
     "sway-workspaces": {},
     "scratchpad": {

--- a/nwg_shell/skel/config/nwg-panel/preset-3
+++ b/nwg_shell/skel/config/nwg-panel/preset-3
@@ -23,7 +23,6 @@
     ],
     "modules-right": [
       "scratchpad",
-      "executor-updates",
       "tray",
       "button-help"
     ],
@@ -113,20 +112,6 @@
       "on-scroll-up": "",
       "on-scroll-down": "",
       "css-name": "clock"
-    },
-    "executor-updates": {
-      "script": "sway-check-updates",
-      "interval": 900,
-      "icon-size": 16,
-      "on-left-click": "foot sway-update",
-      "tooltip-text": "",
-      "on-middle-click": "",
-      "on-right-click": "",
-      "on-scroll-up": "",
-      "on-scroll-down": "",
-      "css-name": "",
-      "root-css-name": "",
-      "icon-placement": "left"
     },
     "sway-workspaces": {
       "numbers": [


### PR DESCRIPTION
To become more distro agnostic sooner or later, we remove the Arch Linux-specific nwg-panel `executor-updates` from  preinstalled configs. The system tray update notifier icon is going to replace it.

This affects new installs. Current users should remove the `updates` executor from their panels, and leave the "Update tray icon" on:

![image](https://user-images.githubusercontent.com/20579136/213835423-1693b2ef-40d6-44ee-a3bb-386537f090ac.png)

For now it works on Arch and derivatives only. To add support for other distros, I expect packagers to cooperate.

Also see: https://github.com/nwg-piotr/nwg-shell/discussions/55