### PR TITLE
Fedora install script and other improvements

### DIFF
--- a/install/arch-dev.sh
+++ b/install/arch-dev.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/bash
 
+if [ "$(id -u)" == 0 ] ; then
+   echo "Please don't run this script as root"
+   exit 1
+fi
+
+# Don't continue script if any error occurs.
+set -e
+
 # wget https://raw.github.com/nwg-piotr/nwg-shell/main/install/arch-dev.sh && chmod u+x arch-dev.sh && ./arch-dev.sh && rm ./arch-dev.sh
 sudo pacman -S --noconfirm git man-db vi xdg-user-dirs
 

--- a/install/arch.sh
+++ b/install/arch.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/bash
 
+if [ "$(id -u)" == 0 ] ; then
+   echo "Please don't run this script as root"
+   exit 1
+fi
+
+# Don't continue script if any error occurs.
+set -e
+
 # wget https://raw.github.com/nwg-piotr/nwg-shell/main/install/arch.sh && chmod u+x arch.sh && ./arch.sh && rm arch.sh
 sudo pacman -S --noconfirm git man-db vi xdg-user-dirs
 

--- a/install/fedora-ostree.sh
+++ b/install/fedora-ostree.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/bash
+
+if [ "$(id -u)" == 0 ] ; then
+   echo "Please don't run this script as root"
+   exit 1
+fi
+
+# Don't continue script if any error occurs.
+set -e
+
+# Check fedora version
+source /etc/os-release
+
+version=$REDHAT_SUPPORT_PRODUCT_VERSION
+
+echo "Enabling nwg-shell Copr"
+sudo curl https://copr.fedorainfracloud.org/coprs/tofik/nwg-shell/repo/fedora-$version/tofik-nwg-shell-fedora-$version.repo -o /etc/yum.repos.d/nwg-shell.repo
+
+echo
+echo "You're about to select components, that need to be preinstalled for the key bindings to work."
+echo "None of above is a shell dependency, and you're free to change them any time later."
+echo
+
+PS3="Select file manager: "
+select fm in thunar caja dolphin nautilus nemo pcmanfm;
+do
+    break
+done
+echo
+
+PS3="Select text editor: "
+select editor in mousepad emacs gedit geany kate vim;
+do
+    break
+done
+echo
+
+PS3="Select web browser: "
+select browser in chromium epiphany falkon firefox konqueror midori qutebrowser seamonkey surf;
+do
+    break
+done
+echo
+
+echo "Installing selection: $fm $editor $browser and nwg-shell"
+rpm-ostree install --allow-inactive $fm $editor $browser nwg-shell
+
+echo "Apply changes live to make nwg-shell-installer available"
+sudo rpm-ostree apply-live
+
+echo "Installing initial configuration"
+# Version in fedora does not support -w flag, so, implemented workaround
+echo y | nwg-shell-installer -a

--- a/install/fedora.sh
+++ b/install/fedora.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/bash
+
+if [ "$(id -u)" == 0 ] ; then
+   echo "Please don't run this script as root"
+   exit 1
+fi
+
+# Don't continue script if any error occurs.
+set -e
+
+echo "Enabling nwg-shell Copr"
+sudo dnf copr enable -y tofik/nwg-shell
+
+echo
+echo "You're about to select components, that need to be preinstalled for the key bindings to work."
+echo "None of above is a shell dependency, and you're free to change them any time later."
+echo
+
+PS3="Select file manager: "
+select fm in thunar caja dolphin nautilus nemo pcmanfm;
+do
+    break
+done
+echo
+
+PS3="Select text editor: "
+select editor in mousepad emacs gedit geany kate vim;
+do
+    break
+done
+echo
+
+PS3="Select web browser: "
+select browser in chromium epiphany falkon firefox konqueror midori qutebrowser seamonkey surf;
+do
+    break
+done
+echo
+
+echo "Installing selection: $fm $editor $browser"
+sudo dnf install -y $fm $editor $browser
+
+echo "Installing nwg-shell"
+sudo dnf install -y nwg-shell
+
+echo "Installing initial configuration"
+# Version in fedora does not support -w flag, so, implemented workaround
+echo y | nwg-shell-installer -a


### PR DESCRIPTION
I implemented an fedora.sh install script to install nwg-shell on Fedora. I also made a small improvements to other scripts. Stopping the script if any error occurs and checking if script is running on root. It is a common mistake to run the script as root. If this happen, the nwg-installer installs config files in root's home directory instead of user. I don't know how to propose changes on wiki to mention that there is a fedora install script. Scripts was tested on Fedora Sway Spin clean installed.