### PR TITLE
Fix missing pamixer

### DIFF
--- a/install/fedora-ostree.sh
+++ b/install/fedora-ostree.sh
@@ -55,3 +55,5 @@ sudo rpm-ostree apply-live
 echo "Installing initial configuration"
 # Version in fedora does not support -w flag, so, implemented workaround
 echo y | nwg-shell-installer -a
+
+xdg-user-dirs-update

--- a/install/fedora-ostree.sh
+++ b/install/fedora-ostree.sh
@@ -16,6 +16,10 @@ version=$REDHAT_SUPPORT_PRODUCT_VERSION
 echo "Enabling nwg-shell Copr"
 sudo curl https://copr.fedorainfracloud.org/coprs/tofik/nwg-shell/repo/fedora-$version/tofik-nwg-shell-fedora-$version.repo -o /etc/yum.repos.d/nwg-shell.repo
 
+echo "Enabling pamixer Copr"
+sudo curl https://copr.fedorainfracloud.org/coprs/notahat/pamixer/repo/fedora-$version/notahat-pamixer-fedora-$version.repo -o /etc/yum.repos.d/pamixer.repo
+
+
 echo
 echo "You're about to select components, that need to be preinstalled for the key bindings to work."
 echo "None of above is a shell dependency, and you're free to change them any time later."
@@ -43,7 +47,7 @@ done
 echo
 
 echo "Installing selection: $fm $editor $browser and nwg-shell"
-rpm-ostree install --allow-inactive $fm $editor $browser nwg-shell
+rpm-ostree install --allow-inactive $fm $editor $browser nwg-shell pamixer
 
 echo "Apply changes live to make nwg-shell-installer available"
 sudo rpm-ostree apply-live

--- a/install/fedora.sh
+++ b/install/fedora.sh
@@ -49,3 +49,5 @@ sudo dnf install -y nwg-shell pamixer
 echo "Installing initial configuration"
 # Version in fedora does not support -w flag, so, implemented workaround
 echo y | nwg-shell-installer -a
+
+xdg-user-dirs-update

--- a/install/fedora.sh
+++ b/install/fedora.sh
@@ -11,6 +11,9 @@ set -e
 echo "Enabling nwg-shell Copr"
 sudo dnf copr enable -y tofik/nwg-shell
 
+echo "Enabling pamixer Copr"
+sudo dnf copr enable -y notahat/pamixer
+
 echo
 echo "You're about to select components, that need to be preinstalled for the key bindings to work."
 echo "None of above is a shell dependency, and you're free to change them any time later."
@@ -41,7 +44,7 @@ echo "Installing selection: $fm $editor $browser"
 sudo dnf install -y $fm $editor $browser
 
 echo "Installing nwg-shell"
-sudo dnf install -y nwg-shell
+sudo dnf install -y nwg-shell pamixer
 
 echo "Installing initial configuration"
 # Version in fedora does not support -w flag, so, implemented workaround


### PR DESCRIPTION
Hello

I fixed the missing pamixer package by adding it to the installer script. I cannot add pamixer as dependency because packaging nwg-shell is not my project. I will try to make PR to the projet to add pamixer as dependency in the future.