### PR TITLE
Removed unused dependency

### DIFF
--- a/install/fedora-ostree.sh
+++ b/install/fedora-ostree.sh
@@ -16,10 +16,6 @@ version=$REDHAT_SUPPORT_PRODUCT_VERSION
 echo "Enabling nwg-shell Copr"
 sudo curl https://copr.fedorainfracloud.org/coprs/tofik/nwg-shell/repo/fedora-$version/tofik-nwg-shell-fedora-$version.repo -o /etc/yum.repos.d/nwg-shell.repo
 
-echo "Enabling pamixer Copr"
-sudo curl https://copr.fedorainfracloud.org/coprs/notahat/pamixer/repo/fedora-$version/notahat-pamixer-fedora-$version.repo -o /etc/yum.repos.d/pamixer.repo
-
-
 echo
 echo "You're about to select components, that need to be preinstalled for the key bindings to work."
 echo "None of above is a shell dependency, and you're free to change them any time later."
@@ -47,7 +43,7 @@ done
 echo
 
 echo "Installing selection: $fm $editor $browser and nwg-shell"
-rpm-ostree install --allow-inactive $fm $editor $browser nwg-shell pamixer
+rpm-ostree install --allow-inactive $fm $editor $browser nwg-shell 
 
 echo "Apply changes live to make nwg-shell-installer available"
 sudo rpm-ostree apply-live

--- a/install/fedora.sh
+++ b/install/fedora.sh
@@ -11,9 +11,6 @@ set -e
 echo "Enabling nwg-shell Copr"
 sudo dnf copr enable -y tofik/nwg-shell
 
-echo "Enabling pamixer Copr"
-sudo dnf copr enable -y notahat/pamixer
-
 echo
 echo "You're about to select components, that need to be preinstalled for the key bindings to work."
 echo "None of above is a shell dependency, and you're free to change them any time later."
@@ -44,7 +41,7 @@ echo "Installing selection: $fm $editor $browser"
 sudo dnf install -y $fm $editor $browser
 
 echo "Installing nwg-shell"
-sudo dnf install -y nwg-shell pamixer
+sudo dnf install -y nwg-shell
 
 echo "Installing initial configuration"
 # Version in fedora does not support -w flag, so, implemented workaround


### PR DESCRIPTION
This PR removes installation of `pamixer` as dependency for `nwg-shell`.
COPR package used in the script patches nwg-shell configs to utilize `pactl` for volume control.