### PR TITLE
Changed volume control bindings to use `pactl`

### DIFF
--- a/nwg_shell/skel/config/sway/config
+++ b/nwg_shell/skel/config/sway/config
@@ -88,9 +88,9 @@ bindsym XF86AudioPlay exec playerctl play-pause
 bindsym XF86AudioNext exec playerctl next
 bindsym XF86AudioPrev exec playerctl previous
 bindsym XF86AudioStop exec playerctl stop
-bindsym XF86AudioMute exec pamixer -t
-bindsym XF86AudioRaiseVolume exec pamixer -i 2
-bindsym XF86AudioLowerVolume exec pamixer -d 2
+bindsym XF86AudioMute exec pactl set-sink-mute 0 toggle
+bindsym XF86AudioRaiseVolume exec pactl set-sink-volume 0 +2%
+bindsym XF86AudioLowerVolume exec pactl set-sink-volume 0 -2%
 
 # backlight
 bindsym XF86MonBrightnessUp exec light -A 5


### PR DESCRIPTION
Changing volume control bindings from using `pamixer` command to `pactl` should improve capability with different Linux distributions, due to fact that `pactl` is part of libpulse/pulseaudio package, which should be available on most distributions and is dependency of `pamixer`.