### PR TITLE
scripts: screenshot: use `/usr/bin/env bash` as interpreter

### DIFF
--- a/scripts/screenshot
+++ b/scripts/screenshot
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Original script based on some early version of https://github.com/moverest/sway-interactive-screenshot
 # modified for use with key bindings. For now supports sway & Hyprland.


### PR DESCRIPTION
The screenshot script won't work on non FHS environments, for example, NixOS.

```
~ > tree /usr
 /usr
└──  bin
   └──  env -> /nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3/bin/env

~ > tree /bin
 /bin
└──  sh -> /nix/store/x88ivkf7rmrhd5x3cvyv5vh3zqqdnhsk-bash-interactive-5.2-p15/bin/sh

~ > screenshot
exec: Failed to execute process '/home/xxx/.local/bin/screenshot': The file specified the interpreter '/bin/bash', which is not an executable command.
```