### PR TITLE
Fix gtk-layer-shell author in credits

### DIFF
--- a/index.md
+++ b/index.md
@@ -54,7 +54,7 @@ If you want to share an idea, find a solution to a problem or discuss the projec
 This collection of software depends on numerous third-party programs and libraries, that have not been mentioned above:
 
 - [wlsunset](https://sr.ht/~kennylevinsen/wlsunset) by Kenny Levinsen
-- [gtk-layer-shell](https://github.com/wmww/gtk-layer-shell) by Dennis Blommesteijn & William Wold
+- [gtk-layer-shell](https://github.com/wmww/gtk-layer-shell) by Sophie Winter
 - [gotk3](https://github.com/gotk3/gotk3) by Conformal Systems LLC
 - [gotk3-layershell](https://github.com/dlasky/gotk3-layershell) by [@dlasky](https://github.com/dlasky/gotk3-layershell/commits?author=dlasky) (Dan, thanks again!)
 - [go-sway](https://github.com/joshuarubin/go-sway) by Joshua Rubin


### PR DESCRIPTION
Hi, glad you find gtk-layer-shell useful. The names credited for it are incorrect. One is my old name, and the other isn't a contributor to the project as far as I know (you probably got it from the copyright notice, I think he's there from when I copied in GTK code?). Anyway, this updates that. Thanks :)