### PR TITLE
Update configurations for foot and sway

### DIFF
--- a/nwg_shell/skel/config/foot/foot.ini
+++ b/nwg_shell/skel/config/foot/foot.ini
@@ -64,7 +64,7 @@ gamma-correct-blending=no
 # hide-when-typing=no
 # alternate-scroll-mode=yes
 
-[colors]
+[colors-dark]
 alpha=0.9
 # foreground=dcdccc
 # background=111111

--- a/nwg_shell/skel/config/sway/config
+++ b/nwg_shell/skel/config/sway/config
@@ -94,8 +94,8 @@ bindsym XF86AudioRaiseVolume exec pactl set-sink-volume 0 +2%
 bindsym XF86AudioLowerVolume exec pactl set-sink-volume 0 -2%
 
 # backlight
-bindsym XF86MonBrightnessUp exec light -A 5
-bindsym XF86MonBrightnessDown exec light -U 5
+bindsym XF86MonBrightnessUp exec brightnessctl s +5%
+bindsym XF86MonBrightnessDown exec brightnessctl s 5%-
 
 # Reload the configuration file
 bindsym $Mod+Shift+c reload


### PR DESCRIPTION
This consists of 2 modifications:

### Foot: 

https://github.com/nwg-piotr/nwg-shell/blob/997b0dfc3cbc2694bddd05b9c0ab61b3ff7e77a1/nwg_shell/skel/config/foot/foot.ini#L67
```diff
--- a/nwg_shell/skel/config/foot/foot.ini
+++ b/nwg_shell/skel/config/foot/foot.ini
@@ -64,7 +64,7 @@ gamma-correct-blending=no
# hide-when-typing=no
# alternate-scroll-mode=yes

-[colors]
+[colors-dark]
alpha=0.9
# foreground=dcdccc
# background=111111
```
Ths prevents this warning:
```console
deprecated: foot: [colors]: use [colors-dark] instead
```

### Sway:

https://github.com/nwg-piotr/nwg-shell/blob/997b0dfc3cbc2694bddd05b9c0ab61b3ff7e77a1/nwg_shell/skel/config/sway/config#L96-L98
```diff
--- a/nwg_shell/skel/config/sway/config
+++ b/nwg_shell/skel/config/sway/config
@@ -94,8 +94,8 @@ bindsym XF86AudioRaiseVolume exec pactl set-sink-volume 0 +2%
bindsym XF86AudioLowerVolume exec pactl set-sink-volume 0 -2%

# backlight
-bindsym XF86MonBrightnessUp exec light -A 5
-bindsym XF86MonBrightnessDown exec light -U 5
+bindsym XF86MonBrightnessUp exec brightnessctl s +5%
+bindsym XF86MonBrightnessDown exec brightnessctl s 5%-

# Reload the configuration file
bindsym $Mod+Shift+c reload
```
`light` seems to be a dead project, or at least I am not able to visit its repository or homepage:
- https://haikarainen.github.io/light/
- https://github.com/haikarainen/light

So I am suggesting here to make `brightnessctl` the default (which `nwg-panel` works with effortlessly).